### PR TITLE
feat: 카페 정보 조회 API

### DIFF
--- a/src/main/java/com/example/springserver/application/cafe/CafeController.java
+++ b/src/main/java/com/example/springserver/application/cafe/CafeController.java
@@ -39,6 +39,15 @@ public class CafeController {
         return ApiResponse.onSuccess(cafeService.postCafe(request, profileImg));
     }
 
+    @Operation(summary = "카페 정보 조회")
+    @GetMapping("/{cafeId}")
+    public ApiResponse<CafeResponseDTO.GetCafeRes> getCafe(
+            @AuthenticationPrincipal CustomUserDetails userDetail,
+            @PathVariable("cafeId") Long cafeId) {
+
+        return ApiResponse.onSuccess(cafeService.getCafe(cafeId));
+    }
+
     @Operation(summary = "카페 정보 수정")
     @PutMapping(value = "/{cafeId}", consumes = "multipart/form-data")
     public ApiResponse<CafeResponseDTO.EditCafeRes> editCafe(

--- a/src/main/java/com/example/springserver/application/customer/CustomerController.java
+++ b/src/main/java/com/example/springserver/application/customer/CustomerController.java
@@ -60,8 +60,6 @@ public class CustomerController {
     @GetMapping("/{customerId}")
     public ApiResponse<CustomerResponseDTO.GetCustomerRes> getCustomer(@AuthenticationPrincipal CustomUserDetails userDetail,
                                                                         @PathVariable Long customerId) {
-        // 본인인지 검사
-        authorizationService.validateUserAuthorization(userDetail.getUsername(), customerId);
 
         return ApiResponse.onSuccess(customerService.getCustomer(customerId));
     }

--- a/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
+++ b/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
@@ -2,12 +2,14 @@ package com.example.springserver.domain.cafe.converter;
 
 import com.example.springserver.domain.cafe.dto.CafeRequestDTO;
 import com.example.springserver.domain.cafe.dto.CafeResponseDTO;
-import com.example.springserver.entity.Cafe;
-import com.example.springserver.entity.StampBoard;
-import com.example.springserver.entity.StampReward;
-import com.example.springserver.entity.UserEntity;
+import com.example.springserver.domain.customer.dto.CustomerResponseDTO;
+import com.example.springserver.domain.keyword.converter.KeywordConverter;
+import com.example.springserver.domain.keyword.dto.KeywordResponseDTO;
+import com.example.springserver.entity.*;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 public class CafeConverter {
 
@@ -44,6 +46,14 @@ public class CafeConverter {
                 .build();
     }
 
+    public static CafeResponseDTO.StampRewardDto toStampRewardDto(StampReward stampReward) {
+        return CafeResponseDTO.StampRewardDto.builder()
+                .stampRewardId(stampReward.getId())
+                .reward(stampReward.getRewardName())
+                .stampCount(stampReward.getStampCount())
+                .build();
+    }
+
     public static CafeResponseDTO.PostCafeRes toPostCafeRes(Cafe cafe){
         return CafeResponseDTO.PostCafeRes.builder()
                 .cafeId(cafe.getId())
@@ -54,6 +64,27 @@ public class CafeConverter {
                 .contact(cafe.getContact())
                 .intro(cafe.getIntro())
                 .imgUrl(cafe.getImgUrl())
+                .build();
+    }
+
+    public static CafeResponseDTO.GetCafeRes toGetCafeRes(Cafe cafe, List<Keyword> keywords, List<StampReward> rewards){
+        List<KeywordResponseDTO.KeywordDto> keywordDtoList = keywords.stream()
+                .map(KeywordConverter::toKeywordDto).toList();
+
+        List<CafeResponseDTO.StampRewardDto> rewardDtoList = rewards.stream()
+                .map(CafeConverter::toStampRewardDto).toList();
+
+        return CafeResponseDTO.GetCafeRes.builder()
+                .cafeId(cafe.getId())
+                .name(cafe.getName())
+                .address(cafe.getAddress())
+                .latitude(cafe.getLatitude())
+                .longitude(cafe.getLongitude())
+                .contact(cafe.getContact())
+                .intro(cafe.getIntro())
+                .imgUrl(cafe.getImgUrl())
+                .rewardList(rewardDtoList)
+                .keywordList(keywordDtoList)
                 .build();
     }
 

--- a/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
+++ b/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
@@ -83,6 +83,7 @@ public class CafeConverter {
                 .contact(cafe.getContact())
                 .intro(cafe.getIntro())
                 .imgUrl(cafe.getImgUrl())
+                .advImgUrl(cafe.getAdvImgUrl())
                 .rewardList(rewardDtoList)
                 .keywordList(keywordDtoList)
                 .build();

--- a/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
+++ b/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
@@ -1,9 +1,12 @@
 package com.example.springserver.domain.cafe.dto;
 
+import com.example.springserver.domain.keyword.dto.KeywordResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 public class CafeResponseDTO {
 
@@ -24,6 +27,23 @@ public class CafeResponseDTO {
         private String contact;
         private String intro;
         private String imgUrl;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetCafeRes {
+        private Long cafeId;
+        private String name;
+        private String address;
+        private Double latitude;
+        private Double longitude;
+        private String contact;
+        private String intro;
+        private String imgUrl;
+        private List<StampRewardDto> rewardList;
+        private List<KeywordResponseDTO.KeywordDto> keywordList;
     }
 
     @Builder
@@ -72,5 +92,15 @@ public class CafeResponseDTO {
         private Integer stampCount;
         private String createdAt;
         private String updatedAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class StampRewardDto {
+        private Long stampRewardId;
+        private String reward;
+        private Integer stampCount;
     }
 }

--- a/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
+++ b/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
@@ -42,6 +42,7 @@ public class CafeResponseDTO {
         private String contact;
         private String intro;
         private String imgUrl;
+        private String advImgUrl;
         private List<StampRewardDto> rewardList;
         private List<KeywordResponseDTO.KeywordDto> keywordList;
     }

--- a/src/main/java/com/example/springserver/domain/cafe/repository/StampRewardRepository.java
+++ b/src/main/java/com/example/springserver/domain/cafe/repository/StampRewardRepository.java
@@ -1,11 +1,15 @@
 package com.example.springserver.domain.cafe.repository;
 
 import com.example.springserver.entity.Cafe;
+import com.example.springserver.entity.KeywordMapping;
 import com.example.springserver.entity.StampReward;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface StampRewardRepository extends JpaRepository<StampReward, Long> {
     Optional<StampReward> findById(Long rewardId);
+
+    List<StampReward> findAllByCafe(Cafe cafe);
 }

--- a/src/main/java/com/example/springserver/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/example/springserver/domain/cafe/service/CafeService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -30,6 +31,7 @@ public class CafeService {
     private final CafeRepository cafeRepository;
     private final StampRewardRepository stampRewardRepository;
     private final UserService userService;
+    private final KeywordService keywordService;
     private final S3Service s3Service;
 
     public Cafe getCafeByUserId(Long userId) {
@@ -40,6 +42,10 @@ public class CafeService {
     public StampReward getStampRewardById(Long rewardId) {
         return stampRewardRepository.findById(rewardId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.REWARD_NOT_FOUND));
+    }
+
+    public List<StampReward> getStampRewardsByCafe(Cafe cafe) {
+        return stampRewardRepository.findAllByCafe(cafe);
     }
 
     public CafeResponseDTO.PostCafeRes postCafe(CafeRequestDTO.PostCafeReq request, MultipartFile profileImg) {
@@ -61,6 +67,15 @@ public class CafeService {
         userService.saveUser(user);
 
         return CafeConverter.toPostCafeRes(newCafe);
+    }
+
+    public CafeResponseDTO.GetCafeRes getCafe(Long cafeId) {
+        Cafe cafe = getCafeByUserId(cafeId);
+
+        List<Keyword> keywords = keywordService.getKeywordsByCafe(cafe);
+        List<StampReward> rewards = getStampRewardsByCafe(cafe);
+        
+        return CafeConverter.toGetCafeRes(cafe, keywords, rewards);
     }
 
     public CafeResponseDTO.EditCafeRes editCafe(CafeRequestDTO.EditCafeReq request, MultipartFile profileImg, Long cafeId) {

--- a/src/main/java/com/example/springserver/domain/keyword/repository/KeywordMappingRepository.java
+++ b/src/main/java/com/example/springserver/domain/keyword/repository/KeywordMappingRepository.java
@@ -1,7 +1,7 @@
 package com.example.springserver.domain.keyword.repository;
 
+import com.example.springserver.entity.Cafe;
 import com.example.springserver.entity.Customer;
-import com.example.springserver.entity.Keyword;
 import com.example.springserver.entity.KeywordMapping;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,6 +9,7 @@ import java.util.List;
 
 public interface KeywordMappingRepository extends JpaRepository<KeywordMapping, Long> {
     List<KeywordMapping> findAllByCustomer(Customer customer);
+    List<KeywordMapping> findAllByCafe(Cafe cafe);
     void deleteByCustomer(Customer customer);
 }
 

--- a/src/main/java/com/example/springserver/domain/keyword/service/KeywordService.java
+++ b/src/main/java/com/example/springserver/domain/keyword/service/KeywordService.java
@@ -58,4 +58,11 @@ public class KeywordService {
                 .map(KeywordMapping::getKeyword)
                 .collect(Collectors.toList());
     }
+
+    public List<Keyword> getKeywordsByCafe(Cafe cafe) {
+        List<KeywordMapping> mappings = keywordMappingRepository.findAllByCafe(cafe);
+        return mappings.stream()
+                .map(KeywordMapping::getKeyword)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 연관 이슈
- #30 

## 내용
- getCafe API 구현 (테스트x)
- 이후에 추가로 쿠폰 발급 현황에 대해 추가 or getCafe API를 소비자 입장과 카페 입장으로 분할