### PR TITLE
카페 정보 관련 API 수정 (운영시간 추가)

### DIFF
--- a/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
+++ b/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
@@ -94,7 +94,6 @@ public class CafeConverter {
                 .contact(cafe.getContact())
                 .intro(cafe.getIntro())
                 .imgUrl(cafe.getImgUrl())
-                .advImgUrl(cafe.getAdvImgUrl())
                 .openTime(formatTime(cafe.getOpenTime()))
                 .closeTime(formatTime(cafe.getCloseTime()))
                 .rewardList(rewardDtoList)
@@ -108,6 +107,8 @@ public class CafeConverter {
             boolean isAddressUpdated,
             boolean isContactUpdated,
             boolean isIntroUpdated,
+            boolean isOpenTimeUpdated,
+            boolean isCloseTimeUpdated,
             boolean isImgUpdated
     ) {
         return CafeResponseDTO.EditCafeRes.builder()
@@ -118,6 +119,8 @@ public class CafeConverter {
                 .longitude(isAddressUpdated ? cafe.getLongitude() : null)
                 .contact(isContactUpdated ? cafe.getContact() : null)
                 .intro(isIntroUpdated ? cafe.getIntro() : null)
+                .openTime(isOpenTimeUpdated ? formatTime(cafe.getOpenTime()) : null)
+                .closeTime(isCloseTimeUpdated ? formatTime(cafe.getCloseTime()) : null)
                 .imgUrl(isImgUpdated ? cafe.getImgUrl() : null)
                 .createdAt(formatDateTime(cafe.getCreatedAt()))
                 .updatedAt(formatDateTime(cafe.getUpdatedAt()))

--- a/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
+++ b/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
@@ -8,6 +8,7 @@ import com.example.springserver.domain.keyword.dto.KeywordResponseDTO;
 import com.example.springserver.entity.*;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -23,6 +24,12 @@ public class CafeConverter {
         return dateTime.format(formatter);
     }
 
+    // 시간을 포맷하는 메서드
+    private static String formatTime(LocalTime time) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        return time.format(formatter);
+    }
+
     public static Cafe toCafe(CafeRequestDTO.PostCafeReq request, UserEntity user, String imgUrl){
 
         return Cafe.builder()
@@ -33,6 +40,8 @@ public class CafeConverter {
                 .longitude(request.getLongitude())
                 .contact(request.getContact())
                 .intro(request.getIntro())
+                .openTime(request.getOpenTime())
+                .closeTime(request.getCloseTime())
                 .imgUrl(imgUrl)
                 .build();
     }
@@ -63,6 +72,8 @@ public class CafeConverter {
                 .longitude(cafe.getLongitude())
                 .contact(cafe.getContact())
                 .intro(cafe.getIntro())
+                .openTime(formatTime(cafe.getOpenTime()))
+                .closeTime(formatTime(cafe.getCloseTime()))
                 .imgUrl(cafe.getImgUrl())
                 .build();
     }
@@ -84,6 +95,8 @@ public class CafeConverter {
                 .intro(cafe.getIntro())
                 .imgUrl(cafe.getImgUrl())
                 .advImgUrl(cafe.getAdvImgUrl())
+                .openTime(formatTime(cafe.getOpenTime()))
+                .closeTime(formatTime(cafe.getCloseTime()))
                 .rewardList(rewardDtoList)
                 .keywordList(keywordDtoList)
                 .build();

--- a/src/main/java/com/example/springserver/domain/cafe/dto/CafeRequestDTO.java
+++ b/src/main/java/com/example/springserver/domain/cafe/dto/CafeRequestDTO.java
@@ -1,9 +1,12 @@
 package com.example.springserver.domain.cafe.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.time.LocalTime;
 
 public class CafeRequestDTO {
 
@@ -25,6 +28,14 @@ public class CafeRequestDTO {
 
         private String contact;
         private String intro;
+
+        @NotNull(message = "오픈 시간은 필수입니다.")
+        @JsonFormat(pattern = "HH:mm")
+        private LocalTime openTime;
+
+        @NotNull(message = "마감 시간은 필수입니다.")
+        @JsonFormat(pattern = "HH:mm")
+        private LocalTime closeTime;
     }
 
     @Getter

--- a/src/main/java/com/example/springserver/domain/cafe/dto/CafeRequestDTO.java
+++ b/src/main/java/com/example/springserver/domain/cafe/dto/CafeRequestDTO.java
@@ -47,6 +47,10 @@ public class CafeRequestDTO {
         private Double longitude;
         private String contact;
         private String intro;
+        @JsonFormat(pattern = "HH:mm")
+        private LocalTime openTime;
+        @JsonFormat(pattern = "HH:mm")
+        private LocalTime closeTime;
     }
 
     @Getter

--- a/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
+++ b/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
@@ -26,6 +26,8 @@ public class CafeResponseDTO {
         private Double longitude;
         private String contact;
         private String intro;
+        private String openTime;
+        private String closeTime;
         private String imgUrl;
     }
 
@@ -43,6 +45,28 @@ public class CafeResponseDTO {
         private String intro;
         private String imgUrl;
         private String advImgUrl;
+        private String openTime;
+        private String closeTime;
+        private List<StampRewardDto> rewardList;
+        private List<KeywordResponseDTO.KeywordDto> keywordList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetMyCafeRes {
+        private Long cafeId;
+        private String name;
+        private String address;
+        private Double latitude;
+        private Double longitude;
+        private String contact;
+        private String intro;
+        private String imgUrl;
+        private String advImgUrl;
+        private String openTime;
+        private String closeTime;
         private List<StampRewardDto> rewardList;
         private List<KeywordResponseDTO.KeywordDto> keywordList;
     }

--- a/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
+++ b/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
@@ -44,7 +44,6 @@ public class CafeResponseDTO {
         private String contact;
         private String intro;
         private String imgUrl;
-        private String advImgUrl;
         private String openTime;
         private String closeTime;
         private List<StampRewardDto> rewardList;
@@ -63,6 +62,8 @@ public class CafeResponseDTO {
         private Double longitude;
         private String contact;
         private String intro;
+        private Long totalStampCount;
+        private Long totalUsedStampCount;
         private String imgUrl;
         private String advImgUrl;
         private String openTime;
@@ -83,6 +84,8 @@ public class CafeResponseDTO {
         private Double longitude;
         private String contact;
         private String intro;
+        private String openTime;
+        private String closeTime;
         private String imgUrl;
         private String createdAt;
         private String updatedAt;

--- a/src/main/java/com/example/springserver/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/example/springserver/domain/cafe/service/CafeService.java
@@ -92,6 +92,8 @@ public class CafeService {
         boolean isAddressUpdated = false;
         boolean isContactUpdated = false;
         boolean isIntroUpdated = false;
+        boolean isOpenTimeUpdated = false;
+        boolean isCloseTimeUpdated = false;
         boolean isImgUpdated = false;
 
         // 이미지 수정
@@ -129,6 +131,18 @@ public class CafeService {
             isIntroUpdated = true;
         }
 
+        // 오픈 시간 수정
+        if (request.getOpenTime() != null) {
+            cafe.setOpenTime(request.getOpenTime());
+            isOpenTimeUpdated = true;
+        }
+
+        // 마감 시간 수정
+        if (request.getCloseTime() != null) {
+            cafe.setCloseTime(request.getCloseTime());
+            isCloseTimeUpdated = true;
+        }
+
         cafeRepository.save(cafe);
 
         return CafeConverter.toEditCafeRes(
@@ -137,6 +151,8 @@ public class CafeService {
                 isAddressUpdated,
                 isContactUpdated,
                 isIntroUpdated,
+                isOpenTimeUpdated,
+                isCloseTimeUpdated,
                 isImgUpdated
         );
     }

--- a/src/main/java/com/example/springserver/domain/customer/converter/CustomerConverter.java
+++ b/src/main/java/com/example/springserver/domain/customer/converter/CustomerConverter.java
@@ -115,11 +115,16 @@ public class CustomerConverter {
                     int availableStamps = stampBoard.getStampsCount() - stampBoard.getUsedStamps();
 
                     // 카페의 StampReward 중에서 availableStamps보다 크거나 같은 것 중 가장 가까운 목표
-                    Integer stampGoal = stampBoard.getCafe().getStampRewards().stream()
+                    // 만약 모든 목표보다 availableStamps이 크다면 가장 큰 목표 반환
+                    List<Integer> stampGoals = stampBoard.getCafe().getStampRewards().stream()
                             .map(StampReward::getStampCount)
+                            .sorted()
+                            .toList();
+
+                    Integer stampGoal = stampGoals.stream()
                             .filter(goal -> goal >= availableStamps)
-                            .min(Integer::compareTo)
-                            .orElse(null);
+                            .findFirst()
+                            .orElseGet(() -> stampGoals.isEmpty() ? null : stampGoals.get(stampGoals.size() - 1));
 
                     return StampConverter.toGetStampBoardRes(stampBoard, stampGoal);
                 })

--- a/src/main/java/com/example/springserver/domain/customer/converter/CustomerConverter.java
+++ b/src/main/java/com/example/springserver/domain/customer/converter/CustomerConverter.java
@@ -13,7 +13,6 @@ import org.springframework.data.domain.Page;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class CustomerConverter {
 

--- a/src/main/java/com/example/springserver/entity/Cafe.java
+++ b/src/main/java/com/example/springserver/entity/Cafe.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+import java.time.LocalTime;
 import java.util.List;
 
 @Entity
@@ -42,6 +43,9 @@ public class Cafe extends BaseEntity {
     private String contact;
     private String intro;
     private String advImgUrl;
+
+    private LocalTime openTime;
+    private LocalTime closeTime;
 
     @OneToMany(mappedBy = "cafe", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<KeywordMapping> keywordMappings;


### PR DESCRIPTION
## 관련 이슈
- #37 

## 내용
- postCafe, editCafe, getCafe에 운영시간 정보 포함
- getCafe를 소비자 관점, 카페 관점으로 분리하여 getMyCafeRes 설정
- searchStampBoard에서 모든 목표보다 사용가능 스탬프가 더 많을 경우 추가