### PR TITLE
feat: getMyCafe API 구현

### DIFF
--- a/src/main/java/com/example/springserver/application/cafe/CafeController.java
+++ b/src/main/java/com/example/springserver/application/cafe/CafeController.java
@@ -48,6 +48,14 @@ public class CafeController {
         return ApiResponse.onSuccess(cafeService.getCafe(cafeId));
     }
 
+    @Operation(summary = "본인 카페 정보 조회")
+    @GetMapping("/my")
+    public ApiResponse<CafeResponseDTO.GetMyCafeRes> getMyCafe(
+            @AuthenticationPrincipal CustomUserDetails userDetail) {
+
+        return ApiResponse.onSuccess(cafeService.getMyCafe(userDetail));
+    }
+
     @Operation(summary = "카페 정보 수정")
     @PutMapping(value = "/{cafeId}", consumes = "multipart/form-data")
     public ApiResponse<CafeResponseDTO.EditCafeRes> editCafe(

--- a/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
+++ b/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
@@ -101,6 +101,36 @@ public class CafeConverter {
                 .build();
     }
 
+    public static CafeResponseDTO.GetMyCafeRes toGetMyCafeRes(Cafe cafe,
+                                                              List<Keyword> keywords,
+                                                              List<StampReward> rewards,
+                                                              Long totalStampCount,
+                                                              Long totalUsedStampCount){
+        List<KeywordResponseDTO.KeywordDto> keywordDtoList = keywords.stream()
+                .map(KeywordConverter::toKeywordDto).toList();
+
+        List<CafeResponseDTO.StampRewardDto> rewardDtoList = rewards.stream()
+                .map(CafeConverter::toStampRewardDto).toList();
+
+        return CafeResponseDTO.GetMyCafeRes.builder()
+                .cafeId(cafe.getId())
+                .name(cafe.getName())
+                .address(cafe.getAddress())
+                .latitude(cafe.getLatitude())
+                .longitude(cafe.getLongitude())
+                .contact(cafe.getContact())
+                .intro(cafe.getIntro())
+                .totalStampCount(totalStampCount)
+                .totalUsedStampCount(totalUsedStampCount)
+                .imgUrl(cafe.getImgUrl())
+                .advImgUrl(cafe.getAdvImgUrl())
+                .openTime(formatTime(cafe.getOpenTime()))
+                .closeTime(formatTime(cafe.getCloseTime()))
+                .rewardList(rewardDtoList)
+                .keywordList(keywordDtoList)
+                .build();
+    }
+
     public static CafeResponseDTO.EditCafeRes toEditCafeRes(
             Cafe cafe,
             boolean isNameUpdated,

--- a/src/main/java/com/example/springserver/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/example/springserver/domain/cafe/service/CafeService.java
@@ -9,12 +9,14 @@ import com.example.springserver.domain.customer.converter.CustomerConverter;
 import com.example.springserver.domain.customer.dto.CustomerRequestDTO;
 import com.example.springserver.domain.customer.dto.CustomerResponseDTO;
 import com.example.springserver.domain.keyword.service.KeywordService;
+import com.example.springserver.domain.stamp.service.StampBoardService;
 import com.example.springserver.domain.user.enums.AccountStatus;
 import com.example.springserver.domain.user.service.UserService;
 import com.example.springserver.entity.*;
 import com.example.springserver.global.common.api.status.ErrorStatus;
 import com.example.springserver.global.exception.GeneralException;
 import com.example.springserver.global.s3.S3Service;
+import com.example.springserver.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +32,7 @@ public class CafeService {
 
     private final CafeRepository cafeRepository;
     private final StampRewardRepository stampRewardRepository;
+    private final StampBoardService stampBoardService;
     private final UserService userService;
     private final KeywordService keywordService;
     private final S3Service s3Service;
@@ -82,6 +85,19 @@ public class CafeService {
         List<StampReward> rewards = getStampRewardsByCafe(cafe);
         
         return CafeConverter.toGetCafeRes(cafe, keywords, rewards);
+    }
+
+    public CafeResponseDTO.GetMyCafeRes getMyCafe(CustomUserDetails userDetail) {
+        Cafe cafe = getCafeByUserId(userDetail.getUserId());
+
+        List<Keyword> keywords = keywordService.getKeywordsByCafe(cafe);
+        List<StampReward> rewards = getStampRewardsByCafe(cafe);
+
+        Object[] result = stampBoardService.findTotalStampsByCafeId(cafe.getId());
+        Long totalStampCount = (Long) result[0];
+        Long totalUsedStampCount = (Long) result[1];
+
+        return CafeConverter.toGetMyCafeRes(cafe, keywords, rewards, totalStampCount, totalUsedStampCount);
     }
 
     public CafeResponseDTO.EditCafeRes editCafe(CafeRequestDTO.EditCafeReq request, MultipartFile profileImg, Long cafeId) {

--- a/src/main/java/com/example/springserver/domain/customer/service/CustomerService.java
+++ b/src/main/java/com/example/springserver/domain/customer/service/CustomerService.java
@@ -172,6 +172,6 @@ public class CustomerService {
 
         Pageable pageable = pageRequest.toPageable();
 
-        return stampBoardService.searchStampBoard(customerId, pageable);
+        return stampBoardService.searchStampBoardByCustomerId(customerId, pageable);
     }
 }

--- a/src/main/java/com/example/springserver/domain/stamp/repository/StampBoardRepository.java
+++ b/src/main/java/com/example/springserver/domain/stamp/repository/StampBoardRepository.java
@@ -4,11 +4,16 @@ import com.example.springserver.entity.StampBoard;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface StampBoardRepository extends JpaRepository<StampBoard, Long> {
     Optional<StampBoard> findStampBoardByCafeIdAndCustomerId(Long cafeId, Long customerId);
 
     Page<StampBoard> findByCustomerId(Long customerId, Pageable pageable);
+
+    @Query("SELECT SUM(s.stampsCount), SUM(s.usedStamps) FROM StampBoard s WHERE s.cafe.id = :cafeId")
+    Object[] findTotalStampsByCafeId(@Param("cafeId") Long cafeId);
+
 }

--- a/src/main/java/com/example/springserver/domain/stamp/service/StampBoardService.java
+++ b/src/main/java/com/example/springserver/domain/stamp/service/StampBoardService.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -36,8 +38,13 @@ public class StampBoardService {
                 });
     }
 
-    public Page<StampBoard> searchStampBoard(Long customerId, Pageable pageable) {
+    public Page<StampBoard> searchStampBoardByCustomerId(Long customerId, Pageable pageable) {
         // 1. StampBoard 검색
         return stampBoardRepository.findByCustomerId(customerId, pageable);
+    }
+
+    public Object[] findTotalStampsByCafeId(Long cafeId) {
+        // 모든 StampBoard 의 stampCount, usedStampCount 합 계산
+        return stampBoardRepository.findTotalStampsByCafeId(cafeId);
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #39 

## 내용
getCafe API를 소비자와 카페 관점으로 둘로 나누기 위해 만들어진 API로 카페 화면에서 본인 카페 정보 조회를 위해 사용하는 API
- advImgUrl 추가
- totalStampCount, totalUsedStampCount 추가