### PR TITLE
feat: searchCafeReviews API 구현 (test x)

### DIFF
--- a/src/main/java/com/example/springserver/application/cafe/CafeController.java
+++ b/src/main/java/com/example/springserver/application/cafe/CafeController.java
@@ -1,18 +1,23 @@
 package com.example.springserver.application.cafe;
 
 import com.example.springserver.domain.auth.service.AuthorizationService;
+import com.example.springserver.domain.cafe.converter.ReviewConverter;
 import com.example.springserver.domain.cafe.dto.BusinessVerificationResponse;
 import com.example.springserver.domain.cafe.dto.CafeRequestDTO;
 import com.example.springserver.domain.cafe.dto.CafeResponseDTO;
 import com.example.springserver.domain.cafe.service.CafeService;
 import com.example.springserver.domain.cafe.service.VerifyBusinessService;
 import com.example.springserver.domain.user.service.UserService;
+import com.example.springserver.entity.Customer;
+import com.example.springserver.entity.Review;
 import com.example.springserver.global.common.api.ApiResponse;
+import com.example.springserver.global.common.paging.CommonPageReq;
 import com.example.springserver.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -144,5 +149,15 @@ public class CafeController {
         authorizationService.validateUserAuthorization(userDetail.getUsername(), request.getCustomerId());
 
         return ApiResponse.onSuccess(cafeService.postReview(request, cafeId));
+    }
+
+    @Operation(summary = "카페 리뷰 검색")
+    @GetMapping(value = "/{cafeId}/reviews")
+    public ApiResponse<CafeResponseDTO.SearchCafeReviewsRes> searchCafeReviews(
+            @AuthenticationPrincipal CustomUserDetails userDetail,
+            @ModelAttribute @Valid CommonPageReq pageRequest,
+            @PathVariable("cafeId") Long cafeId) {
+
+        return ApiResponse.onSuccess(cafeService.searchCafeReviews(pageRequest, cafeId));
     }
 }

--- a/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
+++ b/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
@@ -55,16 +55,6 @@ public class CafeConverter {
                 .build();
     }
 
-    public static Review toReview(CafeRequestDTO.PostReviewReq request, Cafe cafe, Customer customer){
-
-        return Review.builder()
-                .customer(customer)
-                .cafe(cafe)
-                .content(request.getContent())
-                .name(customer.getName())
-                .build();
-    }
-
     public static CafeResponseDTO.StampRewardDto toStampRewardDto(StampReward stampReward) {
         return CafeResponseDTO.StampRewardDto.builder()
                 .stampRewardId(stampReward.getId())
@@ -190,19 +180,4 @@ public class CafeConverter {
                 .build();
     }
 
-    public static CafeResponseDTO.PostReviewRes toPostReviewRes(Review review, List<Keyword> keywords){
-        List<KeywordResponseDTO.KeywordDto> keywordDtoList = keywords.stream()
-                .map(KeywordConverter::toKeywordDto).toList();
-
-        return CafeResponseDTO.PostReviewRes.builder()
-                .reviewId(review.getId())
-                .cafeId(review.getCafe().getId())
-                .customerId(review.getCustomer().getId())
-                .content(review.getContent())
-                .name(review.getName())
-                .keywordList(keywordDtoList)
-                .createdAt(formatDateTime(review.getCreatedAt()))
-                .updatedAt(formatDateTime(review.getUpdatedAt()))
-                .build();
-    }
 }

--- a/src/main/java/com/example/springserver/domain/cafe/converter/ReviewConverter.java
+++ b/src/main/java/com/example/springserver/domain/cafe/converter/ReviewConverter.java
@@ -1,0 +1,86 @@
+package com.example.springserver.domain.cafe.converter;
+
+import com.example.springserver.domain.cafe.dto.CafeRequestDTO;
+import com.example.springserver.domain.cafe.dto.CafeResponseDTO;
+import com.example.springserver.domain.customer.converter.CustomerConverter;
+import com.example.springserver.domain.customer.dto.CustomerResponseDTO;
+import com.example.springserver.domain.keyword.converter.KeywordConverter;
+import com.example.springserver.domain.keyword.dto.KeywordResponseDTO;
+import com.example.springserver.entity.Cafe;
+import com.example.springserver.entity.Customer;
+import com.example.springserver.entity.Keyword;
+import com.example.springserver.entity.Review;
+import com.example.springserver.global.common.paging.CommonPageRes;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class ReviewConverter {
+
+    // 날짜를 포맷하는 메서드
+    private static String formatDateTime(LocalDateTime dateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return dateTime.format(formatter);
+    }
+
+    // 시간을 포맷하는 메서드
+    private static String formatTime(LocalTime time) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        return time.format(formatter);
+    }
+
+    public static Review toReview(CafeRequestDTO.PostReviewReq request, Cafe cafe, Customer customer){
+
+        return Review.builder()
+                .customer(customer)
+                .cafe(cafe)
+                .content(request.getContent())
+                .name(customer.getName())
+                .build();
+    }
+
+    public static CafeResponseDTO.PostReviewRes toPostReviewRes(Review review, List<Keyword> keywords){
+        List<KeywordResponseDTO.KeywordDto> keywordDtoList = keywords.stream()
+                .map(KeywordConverter::toKeywordDto).toList();
+
+        return CafeResponseDTO.PostReviewRes.builder()
+                .reviewId(review.getId())
+                .cafeId(review.getCafe().getId())
+                .customerId(review.getCustomer().getId())
+                .content(review.getContent())
+                .name(review.getName())
+                .keywordList(keywordDtoList)
+                .createdAt(formatDateTime(review.getCreatedAt()))
+                .updatedAt(formatDateTime(review.getUpdatedAt()))
+                .build();
+    }
+
+    public static CafeResponseDTO.GetReviewRes toGetReviewRes(Review review, List<Keyword> keywords){
+        List<KeywordResponseDTO.KeywordDto> keywordDtoList = keywords.stream()
+                .map(KeywordConverter::toKeywordDto).toList();
+
+        return CafeResponseDTO.GetReviewRes.builder()
+                .reviewId(review.getId())
+                .cafeId(review.getCafe().getId())
+                .customerId(review.getCustomer().getId())
+                .name(review.getName())
+                .content(review.getContent())
+                .keywordList(keywordDtoList)
+                .createdAt(formatDateTime(review.getCreatedAt()))
+                .updatedAt(formatDateTime(review.getUpdatedAt()))
+                .build();
+    }
+
+    public static CafeResponseDTO.SearchCafeReviewsRes toSearchCafeReviewsRes(Page<Review> reviewList, List<CafeResponseDTO.GetReviewRes> getReviewResList) {
+
+        return CafeResponseDTO.SearchCafeReviewsRes.builder()
+                .reviewList(getReviewResList)
+                .count(reviewList.getTotalElements())
+                .limit(reviewList.getSize())
+                .page(reviewList.getNumber())
+                .build();
+    }
+}

--- a/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
+++ b/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
@@ -1,10 +1,13 @@
 package com.example.springserver.domain.cafe.dto;
 
 import com.example.springserver.domain.keyword.dto.KeywordResponseDTO;
+import com.example.springserver.domain.stamp.dto.StampResponseDTO;
+import com.example.springserver.global.common.paging.CommonPageRes;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
@@ -145,5 +148,29 @@ public class CafeResponseDTO {
         private List<KeywordResponseDTO.KeywordDto> keywordList;
         private String createdAt;
         private String updatedAt;
+    }
+
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetReviewRes {
+        private Long reviewId;
+        private Long cafeId;
+        private Long customerId;
+        private String name;
+        private String content;
+        private List<KeywordResponseDTO.KeywordDto> keywordList;
+        private String createdAt;
+        private String updatedAt;
+    }
+
+    @SuperBuilder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SearchCafeReviewsRes extends CommonPageRes {
+        private List<CafeResponseDTO.GetReviewRes> reviewList;
     }
 }

--- a/src/main/java/com/example/springserver/domain/cafe/repository/ReviewRepository.java
+++ b/src/main/java/com/example/springserver/domain/cafe/repository/ReviewRepository.java
@@ -1,7 +1,11 @@
 package com.example.springserver.domain.cafe.repository;
 
+import com.example.springserver.entity.Customer;
 import com.example.springserver.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    Page<Review> findByCafeId(Long cafeId, Pageable pageable);
 }

--- a/src/main/java/com/example/springserver/domain/cafe/service/ReviewService.java
+++ b/src/main/java/com/example/springserver/domain/cafe/service/ReviewService.java
@@ -3,6 +3,8 @@ package com.example.springserver.domain.cafe.service;
 import com.example.springserver.domain.cafe.repository.ReviewRepository;
 import com.example.springserver.entity.Review;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,4 +18,6 @@ public class ReviewService {
     public Review toReview(Review review) {
         return reviewRepository.save(review);
     }
+
+    public Page<Review> findReviewByCafeId(Long cafeId, Pageable pageable) { return reviewRepository.findByCafeId(cafeId, pageable);}
 }

--- a/src/main/java/com/example/springserver/domain/keyword/repository/KeywordMappingRepository.java
+++ b/src/main/java/com/example/springserver/domain/keyword/repository/KeywordMappingRepository.java
@@ -3,6 +3,7 @@ package com.example.springserver.domain.keyword.repository;
 import com.example.springserver.entity.Cafe;
 import com.example.springserver.entity.Customer;
 import com.example.springserver.entity.KeywordMapping;
+import com.example.springserver.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.List;
 public interface KeywordMappingRepository extends JpaRepository<KeywordMapping, Long> {
     List<KeywordMapping> findAllByCustomer(Customer customer);
     List<KeywordMapping> findAllByCafe(Cafe cafe);
+    List<KeywordMapping> findAllByReview(Review review);
     void deleteByCustomer(Customer customer);
 }
 

--- a/src/main/java/com/example/springserver/domain/keyword/service/KeywordService.java
+++ b/src/main/java/com/example/springserver/domain/keyword/service/KeywordService.java
@@ -65,4 +65,11 @@ public class KeywordService {
                 .map(KeywordMapping::getKeyword)
                 .collect(Collectors.toList());
     }
+
+    public List<Keyword> getKeywordsByReview(Review review) {
+        List<KeywordMapping> mappings = keywordMappingRepository.findAllByReview(review);
+        return mappings.stream()
+                .map(KeywordMapping::getKeyword)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 연관 이슈
- #57 

## 내용
- ReviewConverter 분리
- cafeId로 해당 카페의 리뷰(키워드 포함) 목록 조회하는 API