### PR TITLE
feat: 소비자 기준 카페 검색 (지도) API 구현 (test x)

### DIFF
--- a/src/main/java/com/example/springserver/application/cafe/CafeController.java
+++ b/src/main/java/com/example/springserver/application/cafe/CafeController.java
@@ -170,4 +170,16 @@ public class CafeController {
 
         return ApiResponse.onSuccess(cafeService.searchCafeReviews(pageRequest, cafeId));
     }
+
+    @Operation(summary = "소비자 기준 카페 검색 (지도)")
+    @GetMapping(value = "/cafes/nearby")
+    public ApiResponse<CafeResponseDTO.SearchCafeNearByRes> searchCafeNearBy(
+            @AuthenticationPrincipal CustomUserDetails userDetail,
+            @RequestParam Double lat,
+            @RequestParam Double lon,
+            @RequestParam(required = false, defaultValue = "3.0") Double radius,
+            @RequestParam(required = false, defaultValue = "distance") String sortBy) {
+
+        return ApiResponse.onSuccess(cafeService.searchCafeNearBy(userDetail, lat, lon, radius, sortBy));
+    }
 }

--- a/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
+++ b/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
@@ -6,6 +6,7 @@ import com.example.springserver.domain.customer.dto.CustomerResponseDTO;
 import com.example.springserver.domain.keyword.converter.KeywordConverter;
 import com.example.springserver.domain.keyword.dto.KeywordResponseDTO;
 import com.example.springserver.entity.*;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -181,4 +182,30 @@ public class CafeConverter {
                 .build();
     }
 
+    public static CafeResponseDTO.GetCafeNearByRes toGetCafeNearByRes(Cafe cafe, List<Keyword> keywords, Double distance){
+        List<KeywordResponseDTO.KeywordDto> keywordDtoList = keywords.stream()
+                .map(KeywordConverter::toKeywordDto).toList();
+
+        return CafeResponseDTO.GetCafeNearByRes.builder()
+                .cafeId(cafe.getId())
+                .name(cafe.getName())
+                .address(cafe.getAddress())
+                .imgUrl(cafe.getImgUrl())
+                .latitude(cafe.getLatitude())
+                .longitude(cafe.getLongitude())
+                .distance(distance)
+                .keywordList(keywordDtoList)
+                .build();
+    }
+
+    public static CafeResponseDTO.SearchCafeNearByRes toSearchCafeNearByRes(
+            List<CafeResponseDTO.GetCafeNearByRes> getCafeNearByList,
+            String sortBy
+    ) {
+
+        return CafeResponseDTO.SearchCafeNearByRes.builder()
+                .cafeList(getCafeNearByList)
+                .sortBy(sortBy)
+                .build();
+    }
 }

--- a/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
+++ b/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
@@ -174,4 +174,28 @@ public class CafeResponseDTO {
     public static class SearchCafeReviewsRes extends CommonPageRes {
         private List<CafeResponseDTO.GetCafeReviewRes> reviewList;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetCafeNearByRes {
+        private Long cafeId;
+        private String name;
+        private String address;
+        private String imgUrl;
+        private Double latitude;
+        private Double longitude;
+        private Double distance;
+        private List<KeywordResponseDTO.KeywordDto> keywordList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SearchCafeNearByRes {
+        private List<CafeResponseDTO.GetCafeNearByRes> cafeList;
+        private String sortBy;
+    }
 }

--- a/src/main/java/com/example/springserver/domain/cafe/repository/CafeRepository.java
+++ b/src/main/java/com/example/springserver/domain/cafe/repository/CafeRepository.java
@@ -3,6 +3,8 @@ package com.example.springserver.domain.cafe.repository;
 import com.example.springserver.entity.Cafe;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.List;
@@ -13,4 +15,7 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
     boolean existsByUserId(Long userId);
     List<Cafe> findAllByOrderByCreatedAtDesc(Pageable pageable);
     List<Cafe> findByNameContainingIgnoreCaseOrderByCreatedAtDesc(String keyword, Pageable pageable);
+
+    @Query("SELECT c FROM Cafe c WHERE c.id IN :ids")
+    List<Cafe> findAllByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/example/springserver/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/example/springserver/domain/cafe/service/CafeService.java
@@ -24,14 +24,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Page;
-import org.springframework.data.geo.Point;
+import org.springframework.data.geo.*;
+import org.springframework.data.redis.connection.RedisGeoCommands;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -338,5 +339,72 @@ public class CafeService {
 
         // 3. 최종 응답 DTO 조립
         return ReviewConverter.toSearchCafeReviewsRes(reviewPage, reviewResList);
+    }
+
+    public CafeResponseDTO.SearchCafeNearByRes searchCafeNearBy(
+            CustomUserDetails userDetail,
+            Double lat,
+            Double lon,
+            Double radius,
+            String sortBy
+    ) {
+        // 1. Redis에서 거리 포함 검색
+        GeoResults<RedisGeoCommands.GeoLocation<String>> geoResults =
+                redisTemplate.opsForGeo().radius(
+                        "cafe-location",
+                        new Circle(new Point(lon, lat), new Distance(radius, Metrics.KILOMETERS)),
+                        RedisGeoCommands.GeoRadiusCommandArgs.newGeoRadiusArgs()
+                                .includeDistance()
+                );
+
+        if (geoResults == null || geoResults.getContent().isEmpty()) {
+            return CafeConverter.toSearchCafeNearByRes(Collections.emptyList(), sortBy);
+        }
+
+        // 2. 카페 ID & 거리 맵 추출
+        List<Long> cafeIds = new ArrayList<>();
+        Map<Long, Double> distanceMap = new HashMap<>();
+
+        for (GeoResult<RedisGeoCommands.GeoLocation<String>> result : geoResults.getContent()) {
+            Long cafeId = Long.valueOf(result.getContent().getName());
+            double distance = result.getDistance().getValue();
+            cafeIds.add(cafeId);
+            distanceMap.put(cafeId, distance);
+        }
+
+        // 3. 카페 정보 조회 (MySQL)
+        List<Cafe> cafes = cafeRepository.findAllByIdIn(cafeIds);
+
+        // 4. 소비자 키워드 조회
+        Customer customer = customerService.getCustomerByUserId(userDetail.getUserId());
+        List<Keyword> customerKeywords = keywordService.getKeywordsByCustomer(customer);
+        Set<Long> customerKeywordIds = customerKeywords.stream()
+                .map(Keyword::getId)
+                .collect(Collectors.toSet());
+
+        // 5. 카페 키워드 조회 + DTO 변환
+        List<CafeResponseDTO.GetCafeNearByRes> resultList = new ArrayList<>();
+
+        for (Cafe cafe : cafes) {
+            List<Keyword> cafeKeywords = keywordService.getKeywordsByCafe(cafe);
+            Double distance = distanceMap.get(cafe.getId());
+
+            resultList.add(CafeConverter.toGetCafeNearByRes(cafe, cafeKeywords, distance));
+        }
+
+        // 6. 정렬
+        if (sortBy.equalsIgnoreCase("preference")) {
+            resultList.sort(Comparator.comparingInt(
+                    (CafeResponseDTO.GetCafeNearByRes dto) ->
+                            (int) dto.getKeywordList().stream()
+                                    .filter(k -> customerKeywordIds.contains(k.getKeywordId()))
+                                    .count()
+            ).reversed());
+        } else {
+            resultList.sort(Comparator.comparingDouble(dto -> distanceMap.get(dto.getCafeId())));
+        }
+
+        // 7. 응답 반환
+        return CafeConverter.toSearchCafeNearByRes(resultList, sortBy);
     }
 }


### PR DESCRIPTION
### 관련 이슈
- #76 

### 내용
- 거리순, 추천순을 구분으로 받고 
- 거리순일 경우, distance를 기준으로 정렬하여 반환
- 추천순일 경우, 키워드 리스트의 교집합 갯수 기준으로 정렬하여 반환