### PR TITLE
feat: 검색어로 카페 검색 API 구현 (test x)

### DIFF
--- a/src/main/java/com/example/springserver/application/cafe/CafeController.java
+++ b/src/main/java/com/example/springserver/application/cafe/CafeController.java
@@ -182,4 +182,13 @@ public class CafeController {
 
         return ApiResponse.onSuccess(cafeService.searchCafeNearBy(userDetail, lat, lon, radius, sortBy));
     }
+
+    @Operation(summary = "검색어로 카페 검색")
+    @GetMapping(value = "/search")
+    public ApiResponse<CafeResponseDTO.SearchCafesRes> searchCafes(
+            @AuthenticationPrincipal CustomUserDetails userDetail,
+            @RequestParam String query) {
+
+        return ApiResponse.onSuccess(cafeService.searchCafes(userDetail, query));
+    }
 }

--- a/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
+++ b/src/main/java/com/example/springserver/domain/cafe/converter/CafeConverter.java
@@ -5,6 +5,7 @@ import com.example.springserver.domain.cafe.dto.CafeResponseDTO;
 import com.example.springserver.domain.customer.dto.CustomerResponseDTO;
 import com.example.springserver.domain.keyword.converter.KeywordConverter;
 import com.example.springserver.domain.keyword.dto.KeywordResponseDTO;
+import com.example.springserver.domain.stamp.converter.StampConverter;
 import com.example.springserver.entity.*;
 import org.springframework.data.domain.Page;
 
@@ -207,6 +208,23 @@ public class CafeConverter {
         return CafeResponseDTO.SearchCafeNearByRes.builder()
                 .cafeList(getCafeNearByList)
                 .sortBy(sortBy)
+                .build();
+    }
+
+    public static CafeResponseDTO.GetCafesRes toGetCafesRes(Cafe cafe, StampBoard stampBoard, String searchBy) {
+        return CafeResponseDTO.GetCafesRes.builder()
+                .cafeId(cafe.getId())
+                .name(cafe.getName())
+                .address(cafe.getAddress())
+                .imgUrl(cafe.getImgUrl())
+                .searchBy(searchBy)
+                .stampBoard(StampConverter.toStampBoardDto(stampBoard))
+                .build();
+    }
+
+    public static CafeResponseDTO.SearchCafesRes toSearchCafesRes(List<CafeResponseDTO.GetCafesRes> cafeList) {
+        return CafeResponseDTO.SearchCafesRes.builder()
+                .cafeList(cafeList)
                 .build();
     }
 }

--- a/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
+++ b/src/main/java/com/example/springserver/domain/cafe/dto/CafeResponseDTO.java
@@ -2,6 +2,7 @@ package com.example.springserver.domain.cafe.dto;
 
 import com.example.springserver.domain.cafe.enums.CafeStatus;
 import com.example.springserver.domain.keyword.dto.KeywordResponseDTO;
+import com.example.springserver.domain.stamp.dto.StampResponseDTO;
 import com.example.springserver.global.common.paging.CommonPageRes;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -199,5 +200,26 @@ public class CafeResponseDTO {
     public static class SearchCafeNearByRes {
         private List<CafeResponseDTO.GetCafeNearByRes> cafeList;
         private String sortBy;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetCafesRes {
+        private Long cafeId;
+        private String name;
+        private String address;
+        private String imgUrl;
+        private String searchBy;
+        private StampResponseDTO.StampBoardDto stampBoard;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SearchCafesRes {
+        private List<CafeResponseDTO.GetCafesRes> cafeList;
     }
 }

--- a/src/main/java/com/example/springserver/domain/cafe/repository/CafeRepository.java
+++ b/src/main/java/com/example/springserver/domain/cafe/repository/CafeRepository.java
@@ -16,6 +16,7 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
     List<Cafe> findAllByOrderByCreatedAtDesc(Pageable pageable);
     List<Cafe> findAllByOrderByCreatedAtDesc();
     List<Cafe> findByNameContainingIgnoreCaseOrderByCreatedAtDesc(String keyword, Pageable pageable);
+    List<Cafe> findByNameContaining(String query);
 
     @Query("SELECT c FROM Cafe c WHERE c.id IN :ids")
     List<Cafe> findAllByIdIn(@Param("ids") List<Long> ids);

--- a/src/main/java/com/example/springserver/domain/keyword/repository/KeywordMappingRepository.java
+++ b/src/main/java/com/example/springserver/domain/keyword/repository/KeywordMappingRepository.java
@@ -1,9 +1,6 @@
 package com.example.springserver.domain.keyword.repository;
 
-import com.example.springserver.entity.Cafe;
-import com.example.springserver.entity.Customer;
-import com.example.springserver.entity.KeywordMapping;
-import com.example.springserver.entity.Review;
+import com.example.springserver.entity.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -13,5 +10,6 @@ public interface KeywordMappingRepository extends JpaRepository<KeywordMapping, 
     List<KeywordMapping> findAllByCafe(Cafe cafe);
     List<KeywordMapping> findAllByReview(Review review);
     void deleteByCustomer(Customer customer);
+    List<KeywordMapping> findAllByKeywordInAndCafeIsNotNull(List<Keyword> keywords);
 }
 

--- a/src/main/java/com/example/springserver/domain/stamp/converter/StampConverter.java
+++ b/src/main/java/com/example/springserver/domain/stamp/converter/StampConverter.java
@@ -38,6 +38,15 @@ public class StampConverter {
                 .build();
     }
 
+    public static StampResponseDTO.StampBoardDto toStampBoardDto(StampBoard stampBoard){
+        if (stampBoard == null) return null;
+
+        return StampResponseDTO.StampBoardDto.builder()
+                .stampBoardId(stampBoard.getId())
+                .stampCount(stampBoard.getStampsCount()-stampBoard.getUsedStamps())
+                .build();
+    }
+
     public static StampResponseDTO.PostStampRes toPostStampRes(StampBoard stampBoard){
         return StampResponseDTO.PostStampRes.builder()
                 .stampBoardId(stampBoard.getId())

--- a/src/main/java/com/example/springserver/domain/stamp/dto/StampResponseDTO.java
+++ b/src/main/java/com/example/springserver/domain/stamp/dto/StampResponseDTO.java
@@ -35,4 +35,13 @@ public class StampResponseDTO {
         private Integer stampCount;
         private Integer stampGoal;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class StampBoardDto {
+        private Long stampBoardId;
+        private Integer stampCount;
+    }
 }

--- a/src/main/java/com/example/springserver/domain/stamp/service/StampBoardService.java
+++ b/src/main/java/com/example/springserver/domain/stamp/service/StampBoardService.java
@@ -28,6 +28,12 @@ public class StampBoardService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.STAMPBOARD_NOT_FOUND));
     }
 
+    public StampBoard findStampBoard(Cafe cafe, Customer customer) {
+        // 1. StampBoard 조회
+        return stampBoardRepository.findStampBoardByCafeIdAndCustomerId(cafe.getId(), customer.getId())
+                .orElse(null);
+    }
+
     public StampBoard getStampBoardOrPost(Cafe cafe, Customer customer) {
         // 1. StampBoard 조회
         return stampBoardRepository.findStampBoardByCafeIdAndCustomerId(cafe.getId(), customer.getId())


### PR DESCRIPTION
### 연관 이슈
- #95 

### 내용
- 검색어를 입력받고 카페 반환
- 카페 이름에 포함되면 이름으로 검색된 카페 포함
- 검색어에서 키워드 추출 후 키워드 기반으로 카페 검색 후 포함
- 방문했던 카페면 스탬프 보드 반환